### PR TITLE
Setup Sentry + Some thoughts on session recodings ala Matomo / Posthogg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import * as Sentry from "@sentry/react";
 
 import App from "./App";
 import GLOB from "./ENVIRONMENT";
@@ -25,6 +26,20 @@ if (GLOB.DEVELOPMENT) {
   });
 } else {
   window.renderApp = ({ initData }, { apiTranslations }) => {
+    
+    Sentry.init({
+      dsn: "https://9726397c1f42ffb5d79cbcc31dfe3c8e@s.t1m.me/3",
+      integrations: [
+        new Sentry.BrowserTracing({
+          tracePropagationTargets: ["localhost", /^https:\/\/little-world\.com\/api/],
+        }),
+        new Sentry.Replay(),
+      ],
+      tracesSampleRate: 1.0,
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1.0,
+    });
+
     updateTranslationResources({ apiTranslations }); // This adds all form translations from the backend!
     // If not in development just render ...
     ReactDOM.render(


### PR DESCRIPTION
Heyyo, @Simba14  you some time ago suggested to use a error tracking tool also in the front-end.

Specially now that we deploy the new user-form soon it will be very helpful to get real-time error reports.

I've been looking in some options and I like `sentry.io` as well, 
they have [a pretty cool helm chart](https://github.com/sentry-kubernetes/charts) that I can easily self host; already do [`s.t1m.me`](https://s.t1m.me) I've tested the integration in my blog and [`msgmate.io`](https://msgmate.io) and it works perfectly for error and trace reporting, also sending email allerts etc...

I can invite you there and we have basically all pro features with some limitations. 

I have also tested the session recondings feature, and since its based on page elements it seems to be broken for our frontends ( I also tested it using sentry.io itself, rather then my hosted server ).


Also I'd love to try out session recodings in some capacity, especially for frontend error reports they can be quite usefull.

I've tested posthog.com, or rather their eu hosting eu.posthog.com, and it very very nice out of the box.
Matomo what we already use also offers this but for 240dollar/year: https://plugins.matomo.org/HeatmapSessionRecording#preview

Also we have to consider that at least for adding posthogg we would also need to add that we're using it in the privacy policy.

I think for now lets just go with sentry. That we don't even have to add to the policy since we self host it in germany :D .