### PR TITLE
chore: move api endpoints to separate endpoints file

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,14 +3,14 @@ import useSWR, { mutate, SWRConfig } from 'swr';
 
 import './App.css';
 
-import { useDevelopmentFeaturesStore } from './features/stores/index';
 import {
   API_OPTIONS_ENDPOINT,
   API_TRANSLATIONS_ENDPOINT,
   IS_AUTHENTICATED_ENDPOINT,
   swrConfig,
   USER_ENDPOINT,
-} from './features/swr/index';
+} from './api/endpoints';
+import { useDevelopmentFeaturesStore } from './features/stores/index';
 import router from './router/router';
 
 function Preloader({ children }) {

--- a/src/Firebase.tsx
+++ b/src/Firebase.tsx
@@ -9,9 +9,9 @@ import {
 } from '@firebase/messaging';
 import useSWR from 'swr';
 
+import { USER_ENDPOINT } from './api/endpoints';
 import { ToastContextType } from './components/blocks/Toast';
 import useNotificationStore from './features/stores/notification';
-import { USER_ENDPOINT } from './features/swr/index';
 import { disableFirebase, enableFirebase } from './firebase-util';
 import useToast from './hooks/useToast';
 

--- a/src/WebsocketBridge.jsx
+++ b/src/WebsocketBridge.jsx
@@ -6,15 +6,15 @@ import { mutate } from 'swr';
 import './App.css';
 
 import {
+  NOTIFICATIONS_ENDPOINT,
+  UNREAD_NOTIFICATIONS_ENDPOINT,
+} from './api/endpoints';
+import {
   useEffectiveBackendUrl,
   useEffectiveCoreWsScheme,
 } from './api/helpers';
 import { environment } from './environment';
 import useNativeStore from './features/stores/nativeStore';
-import {
-  NOTIFICATIONS_ENDPOINT,
-  UNREAD_NOTIFICATIONS_ENDPOINT,
-} from './features/swr';
 import { runWsBridgeMutation } from './features/swr/wsBridgeMutations';
 import useToast from './hooks/useToast';
 

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1,0 +1,33 @@
+export const USER_ENDPOINT = '/api/user';
+export const IS_AUTHENTICATED_ENDPOINT = '/api/user/authenticated';
+export const COMMUNITY_EVENTS_ENDPOINT = '/api/community';
+export const RANDOM_CALL_HISTORY_ENDPOINT = '/api/random_calls/user/history';
+export const RANDOM_CALL_LOBBY_ENDPOINT =
+  '/api/random_calls/lobby/default/active_or_upcoming';
+export const UPCOMING_LOBBIES_ENDPOINT =
+  '/api/random_calls/upcoming?name=default';
+export const RANDOM_CALL_EXIT_PARAM = 'randomCallEnded';
+export const RANDOM_CALL_EXIT_VALUE = '1';
+export const apiOptions = '#api_options';
+export const API_OPTIONS_ENDPOINT = '/api/api_options';
+export const FIREBASE_ENDPOINT = '/api/firebase';
+export const MATCHES_ENDPOINT = '/api/matches';
+export const getMatchOverviewEndpoint = (matchUuid: string) =>
+  `/api/matches/${matchUuid}/overview`;
+export const ACTIVE_CALL_ROOMS_ENDPOINT = '/api/call_rooms';
+export const NOTIFICATIONS_ENDPOINT = '/api/notifications';
+export const UNREAD_NOTIFICATIONS_ENDPOINT = '/api/notifications?filter=unread';
+export const CHATS_ENDPOINT = '/api/chats/?page_size=20';
+export const CHATS_ENDPOINT_SEPERATE =
+  '/api/chats/?page_size=20&pagination=true';
+export const API_TRANSLATIONS_ENDPOINT = '/api/translations';
+
+export const getChatEndpoint = (chatId: string) => `/api/chats/${chatId}/`;
+export const getChatMessagesEndpoint = (chatId: string, page: number) =>
+  `/api/messages/${chatId}/?page=${page}&page_size=20`;
+export const getCommunityEventsEndpoint = (page: number, pageSize = 15) =>
+  `/api/community?page=${page}&page_size=${pageSize}`;
+export const getMatchEndpoint = (page: number) =>
+  `/api/matches?page=${page}&page_size=10`;
+export const getQuestionsEndpoint = (archived: boolean) =>
+  `/api/user/question_cards/?archived=${archived}&category=all`;

--- a/src/components/blocks/CallHistory/CallHistory.tsx
+++ b/src/components/blocks/CallHistory/CallHistory.tsx
@@ -15,8 +15,8 @@ import { useTranslation } from 'react-i18next';
 import { useTheme } from 'styled-components';
 import useSWR, { mutate } from 'swr';
 
+import { RANDOM_CALL_HISTORY_ENDPOINT } from '../../../api/endpoints';
 import { requestRandomCallMatch } from '../../../api/randomCalls';
-import { RANDOM_CALL_HISTORY_ENDPOINT } from '../../../features/swr';
 import { formatDate, formatDuration } from '../../../helpers/date';
 import useToast from '../../../hooks/useToast';
 import ProfileImage from '../../atoms/ProfileImage';

--- a/src/components/blocks/Calls/CallSetup.tsx
+++ b/src/components/blocks/Calls/CallSetup.tsx
@@ -21,9 +21,9 @@ import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import useSWR from 'swr';
 
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import { requestVideoAccessToken } from '../../../api/livekit';
 import { useConnectedCallStore } from '../../../features/stores';
-import { USER_ENDPOINT } from '../../../features/swr/index';
 import { clearActiveTracks } from '../../../helpers/video';
 import { getCallRoute } from '../../../router/routes';
 import { MEDIA_DEVICE_MENU_CSS } from '../../views/VideoCall.styles';

--- a/src/components/blocks/Calls/SidebarNotes.tsx
+++ b/src/components/blocks/Calls/SidebarNotes.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { TextTypes } from '@a-little-world/little-world-design-system';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
-import { USER_ENDPOINT } from '../../../features/swr/index';
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import {
   addUserNote,
   deleteUserNote,

--- a/src/components/blocks/Cards/ConfirmMatchCard.tsx
+++ b/src/components/blocks/Cards/ConfirmMatchCard.tsx
@@ -23,9 +23,10 @@ import { useTranslation } from 'react-i18next';
 import styled, { useTheme } from 'styled-components';
 import useSWR from 'swr';
 
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import { respondToProposedMatch } from '../../../api/matches';
 import { MATCH_TYPES } from '../../../constants';
-import { revalidateMatches, USER_ENDPOINT } from '../../../features/swr/index';
+import { revalidateMatches } from '../../../features/swr';
 import {
   buildAvailabilityRows,
   formatSuggestedAvailabilityOverlap,

--- a/src/components/blocks/Cards/PartnerActionCard.tsx
+++ b/src/components/blocks/Cards/PartnerActionCard.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { reportIssue, unmatch } from '../../../api/matches';
-import { revalidateMatches } from '../../../features/swr/index';
+import { revalidateMatches } from '../../../features/swr';
 import { REPORT_TYPE_UNMATCH, ReportType } from '../ReportForm/constants';
 import ReportForm from '../ReportForm/ReportForm';
 

--- a/src/components/blocks/Cards/ProfileCard.tsx
+++ b/src/components/blocks/Cards/ProfileCard.tsx
@@ -28,8 +28,8 @@ import { Link as RouterLink } from 'react-router-dom';
 import styled, { css, useTheme } from 'styled-components';
 import useSWR from 'swr';
 
+import { CHATS_ENDPOINT } from '../../../api/endpoints';
 import { useCallSetupStore } from '../../../features/stores/index';
-import { CHATS_ENDPOINT } from '../../../features/swr/index';
 import {
   getAppRoute,
   getAppSubpageRoute,

--- a/src/components/blocks/Cards/SearchingCard.tsx
+++ b/src/components/blocks/Cards/SearchingCard.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import styled, { css } from 'styled-components';
 import useSWR from 'swr';
 
-import { USER_ENDPOINT } from '../../../features/swr/index';
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import { formatDate, formatTime } from '../../../helpers/date';
 import { getAppRoute, USER_FORM_ROUTES } from '../../../router/routes';
 import { PROFILE_CARD_HEIGHT } from './ProfileCard';

--- a/src/components/blocks/CategorySelector/CategorySelector.jsx
+++ b/src/components/blocks/CategorySelector/CategorySelector.jsx
@@ -10,7 +10,7 @@ import useSWR from 'swr';
 import {
   IS_AUTHENTICATED_ENDPOINT,
   USER_ENDPOINT,
-} from '../../../features/swr/index';
+} from '../../../api/endpoints';
 import {
   CategoryNote,
   CategorySelectorWrapper,

--- a/src/components/blocks/ChatCore/Chat.tsx
+++ b/src/components/blocks/ChatCore/Chat.tsx
@@ -31,16 +31,16 @@ import {
   sendMessage,
 } from '../../../api/chat';
 import {
-  useCallSetupStore,
-  useChatInputStore,
-} from '../../../features/stores/index';
-import {
   CHATS_ENDPOINT_SEPERATE,
   getChatEndpoint,
   getChatMessagesEndpoint,
-  revalidateChats,
   USER_ENDPOINT,
-} from '../../../features/swr/index';
+} from '../../../api/endpoints';
+import {
+  useCallSetupStore,
+  useChatInputStore,
+} from '../../../features/stores/index';
+import { revalidateChats } from '../../../features/swr';
 import { addMessage } from '../../../features/swr/wsBridgeMutations';
 import {
   formatFileName,

--- a/src/components/blocks/ChatCore/ChatWithUserInfo.tsx
+++ b/src/components/blocks/ChatCore/ChatWithUserInfo.tsx
@@ -21,8 +21,8 @@ import { Link as RouterLink } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import useSWR from 'swr';
 
+import { getChatEndpoint, USER_ENDPOINT } from '../../../api/endpoints';
 import { useCallSetupStore } from '../../../features/stores/index';
-import { getChatEndpoint, USER_ENDPOINT } from '../../../features/swr/index';
 import { getAppRoute, PROFILE_ROUTE } from '../../../router/routes';
 import { CircleImageLoading, LoadingLine } from '../../atoms/Loading';
 import SupportTag from '../../atoms/SupportTag';

--- a/src/components/blocks/ChatCore/ChatsPanel.tsx
+++ b/src/components/blocks/ChatCore/ChatsPanel.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next';
 import styled, { css, useTheme } from 'styled-components';
 import useSWR from 'swr';
 
-import { USER_ENDPOINT } from '../../../features/swr/index';
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import {
   getCustomChatElements,
   processAttachmentWidgets,

--- a/src/components/blocks/CommsBanner.tsx
+++ b/src/components/blocks/CommsBanner.tsx
@@ -5,7 +5,7 @@ import {
 import { isEmpty } from 'lodash';
 import useSWR from 'swr';
 
-import { USER_ENDPOINT } from '../../features/swr/index';
+import { USER_ENDPOINT } from '../../api/endpoints';
 
 function CommsBanner() {
   const banner = useSWR(USER_ENDPOINT).data?.banner;

--- a/src/components/blocks/CommunityEvents/CommunityEvent.tsx
+++ b/src/components/blocks/CommunityEvents/CommunityEvent.tsx
@@ -16,12 +16,12 @@ import { useNavigate } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import useSWR from 'swr';
 
-import { COMMUNITY_EVENT_FREQUENCIES } from '../../../constants/index';
-import CustomPagination from '../../../CustomPagination';
 import {
   getCommunityEventsEndpoint,
   UPCOMING_LOBBIES_ENDPOINT,
-} from '../../../features/swr/index';
+} from '../../../api/endpoints';
+import { COMMUNITY_EVENT_FREQUENCIES } from '../../../constants/index';
+import CustomPagination from '../../../CustomPagination';
 import { formatDate, formatEventTime } from '../../../helpers/date';
 import { calculateNextOccurrence, Event } from '../../../helpers/events';
 import { type UpcomingLobbyItem } from '../../../helpers/randomCalls';

--- a/src/components/blocks/Form/Form.tsx
+++ b/src/components/blocks/Form/Form.tsx
@@ -10,11 +10,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import useSWR from 'swr';
 
 import { completeForm, mutateUserData } from '../../../api';
+import { API_OPTIONS_ENDPOINT, USER_ENDPOINT } from '../../../api/endpoints';
 import { USER_FIELDS, USER_TYPES } from '../../../constants';
-import {
-  API_OPTIONS_ENDPOINT,
-  USER_ENDPOINT,
-} from '../../../features/swr/index';
 import { onFormError } from '../../../helpers/form';
 import {
   EDIT_FORM_ROUTE,

--- a/src/components/blocks/Header.tsx
+++ b/src/components/blocks/Header.tsx
@@ -3,12 +3,9 @@ import { useTranslation } from 'react-i18next';
 import styled, { css } from 'styled-components';
 import useSWR from 'swr';
 
+import { IS_AUTHENTICATED_ENDPOINT, USER_ENDPOINT } from '../../api/endpoints';
 import { USER_TYPES } from '../../constants';
 import { environment } from '../../environment';
-import {
-  IS_AUTHENTICATED_ENDPOINT,
-  USER_ENDPOINT,
-} from '../../features/swr/index';
 import {
   getAppRoute,
   getHomeRoute,

--- a/src/components/blocks/Layout/AppLayout.tsx
+++ b/src/components/blocks/Layout/AppLayout.tsx
@@ -10,6 +10,11 @@ import {
 import styled, { css } from 'styled-components';
 import useSWR from 'swr';
 
+import {
+  ACTIVE_CALL_ROOMS_ENDPOINT,
+  MATCHES_ENDPOINT,
+  USER_ENDPOINT,
+} from '../../../api/endpoints';
 import { submitCallFeedback } from '../../../api/livekit';
 import { pagesWithViewportHeight, USER_TYPES } from '../../../constants/index';
 import {
@@ -20,11 +25,6 @@ import {
 import useModalManagerStore, {
   ModalTypes,
 } from '../../../features/stores/modalManager';
-import {
-  ACTIVE_CALL_ROOMS_ENDPOINT,
-  MATCHES_ENDPOINT,
-  USER_ENDPOINT,
-} from '../../../features/swr/index';
 import { blockIncomingCall } from '../../../features/swr/wsBridgeMutations';
 import { getAppRoute, ONBOARDING_ROUTE } from '../../../router/routes';
 import LoadingScreen from '../../atoms/LoadingScreen';

--- a/src/components/blocks/MailingLists/MailingLists.tsx
+++ b/src/components/blocks/MailingLists/MailingLists.tsx
@@ -13,9 +13,9 @@ import { useParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import useSWR, { mutate } from 'swr';
 
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import { apiFetch } from '../../../api/helpers';
 import { mutateUserData } from '../../../api/index';
-import { USER_ENDPOINT } from '../../../features/swr/index';
 import { onFormError } from '../../../helpers/form';
 
 const MailingListsWrapper = styled.div<{ $centred?: boolean; $width?: string }>`

--- a/src/components/blocks/MobileNavBar.jsx
+++ b/src/components/blocks/MobileNavBar.jsx
@@ -12,8 +12,8 @@ import { useLocation, useParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import useSWR from 'swr';
 
+import { CHATS_ENDPOINT } from '../../api/endpoints';
 import { useDevelopmentFeaturesStore } from '../../features/stores/index';
-import { CHATS_ENDPOINT } from '../../features/swr/index';
 import { APP_ROUTE } from '../../router/routes';
 import Logo from '../atoms/Logo';
 import NotificationBell from '../atoms/NotificationBell';

--- a/src/components/blocks/NotificationPanel.tsx
+++ b/src/components/blocks/NotificationPanel.tsx
@@ -9,11 +9,11 @@ import { useTranslation } from 'react-i18next';
 import styled, { css, useTheme } from 'styled-components';
 import useSWR from 'swr';
 
-import { useDevelopmentFeaturesStore } from '../../features/stores/index';
 import {
   UNREAD_NOTIFICATIONS_ENDPOINT,
   USER_ENDPOINT,
-} from '../../features/swr/index';
+} from '../../api/endpoints';
+import { useDevelopmentFeaturesStore } from '../../features/stores/index';
 import { formatTimeDistance } from '../../helpers/date';
 import { getAppRoute, NOTIFICATIONS_ROUTE } from '../../router/routes';
 import MatchingUserTag from '../atoms/MatchingUserTag';

--- a/src/components/blocks/PartnerProfiles.tsx
+++ b/src/components/blocks/PartnerProfiles.tsx
@@ -12,13 +12,13 @@ import { useTranslation } from 'react-i18next';
 import styled, { css } from 'styled-components';
 import useSWR from 'swr';
 
+import { getMatchEndpoint, USER_ENDPOINT } from '../../api/endpoints';
 import {
   COUNTRIES,
   LANGUAGE_LEVELS,
   LANGUAGES,
   USER_TYPES,
 } from '../../constants';
-import { getMatchEndpoint, USER_ENDPOINT } from '../../features/swr';
 import useSystemModalBlocker from '../../hooks/useSystemModalBlocker';
 import PlusImage from '../../images/plus-with-circle.svg';
 import LanguageLevelCard from './Cards/LanguageLevelCard';

--- a/src/components/blocks/Profile/ProfileEditor.tsx
+++ b/src/components/blocks/Profile/ProfileEditor.tsx
@@ -12,7 +12,7 @@ import styled from 'styled-components';
 import { mutate } from 'swr';
 
 import { mutateUserData } from '../../../api';
-import { USER_ENDPOINT } from '../../../features/swr/index';
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import { onFormError } from '../../../helpers/form';
 import ModalCard, { ModalTitle } from '../Cards/ModalCard';
 import FormStep from '../Form/FormStep';

--- a/src/components/blocks/Profile/ProfilePic/ProfilePic.tsx
+++ b/src/components/blocks/Profile/ProfilePic/ProfilePic.tsx
@@ -27,8 +27,8 @@ import Avatar, { genConfig } from 'react-nice-avatar';
 import { useTheme } from 'styled-components';
 import useSWR from 'swr';
 
+import { USER_ENDPOINT } from '../../../../api/endpoints';
 import { USER_FIELDS } from '../../../../constants/index';
-import { USER_ENDPOINT } from '../../../../features/swr/index';
 import useImageCompression from '../../../../hooks/useImageCompression';
 import useSystemModalBlocker from '../../../../hooks/useSystemModalBlocker';
 import { ImageSizes } from '../../../atoms/ProfileImage';

--- a/src/components/blocks/PushNotifications/PushNotifications.tsx
+++ b/src/components/blocks/PushNotifications/PushNotifications.tsx
@@ -6,11 +6,11 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import useSWR, { mutate } from 'swr';
 
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import { mutateUserData } from '../../../api/index';
 import { environment } from '../../../environment';
 import { useDevelopmentFeaturesStore } from '../../../features/stores/index';
 import useNotificationStore from '../../../features/stores/notification';
-import { USER_ENDPOINT } from '../../../features/swr/index';
 import {
   registerFirebaseDeviceToken,
   sendFirebaseTestNotification,

--- a/src/components/blocks/QuestionCards/QuestionCards.tsx
+++ b/src/components/blocks/QuestionCards/QuestionCards.tsx
@@ -15,8 +15,8 @@ import { isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import useSWR, { mutate } from 'swr';
 
+import { getQuestionsEndpoint } from '../../../api/endpoints';
 import { archieveQuestion } from '../../../api/questions';
-import { getQuestionsEndpoint } from '../../../features/swr/index';
 import {
   Categories,
   CategoryControl,

--- a/src/components/blocks/RandomCalls/RandomCallsLobby.tsx
+++ b/src/components/blocks/RandomCalls/RandomCallsLobby.tsx
@@ -30,6 +30,12 @@ import styled, { css, useTheme } from 'styled-components';
 import useSWR from 'swr';
 
 import {
+  RANDOM_CALL_EXIT_PARAM,
+  RANDOM_CALL_EXIT_VALUE,
+  UPCOMING_LOBBIES_ENDPOINT,
+  USER_ENDPOINT,
+} from '../../../api/endpoints';
+import {
   acceptMatch,
   authenticateRoom,
   exitLobby,
@@ -39,12 +45,6 @@ import {
 } from '../../../api/randomCalls';
 import { COMMUNITY_EVENT_FREQUENCIES, USER_TYPES } from '../../../constants';
 import { useConnectedCallStore } from '../../../features/stores';
-import {
-  RANDOM_CALL_EXIT_PARAM,
-  RANDOM_CALL_EXIT_VALUE,
-  UPCOMING_LOBBIES_ENDPOINT,
-  USER_ENDPOINT,
-} from '../../../features/swr';
 import { type UpcomingLobbyItem } from '../../../helpers/randomCalls';
 import { clearActiveTracks } from '../../../helpers/video';
 import {

--- a/src/components/blocks/Sidebar.jsx
+++ b/src/components/blocks/Sidebar.jsx
@@ -24,7 +24,7 @@ import {
   CHATS_ENDPOINT,
   NOTIFICATIONS_ENDPOINT,
   USER_ENDPOINT,
-} from '../../features/swr/index';
+} from '../../api/endpoints';
 import {
   COMMUNITY_EVENTS_ROUTE,
   getAppRoute,

--- a/src/components/views/ChangeEmail.jsx
+++ b/src/components/views/ChangeEmail.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
   Button,
@@ -16,7 +16,7 @@ import { useNavigate } from 'react-router-dom';
 import { mutate } from 'swr';
 
 import { setNewEmail } from '../../api';
-import { USER_ENDPOINT } from '../../features/swr/index';
+import { USER_ENDPOINT } from '../../api/endpoints';
 import { onFormError, registerInput } from '../../helpers/form';
 import { getAppRoute, VERIFY_EMAIL_ROUTE } from '../../router/routes';
 import ButtonsContainer from '../atoms/ButtonsContainer';

--- a/src/components/views/Help.tsx
+++ b/src/components/views/Help.tsx
@@ -10,7 +10,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import { SWRConfig } from 'swr';
 
-import { swrConfig } from '../../features/swr/index';
+import { swrConfig } from '../../features/swr';
 import useSupportChat, { type SupportMatch } from '../../hooks/useSupportChat';
 import {
   getAppRoute,

--- a/src/components/views/Home.tsx
+++ b/src/components/views/Home.tsx
@@ -5,14 +5,14 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import useSWR, { mutate } from 'swr';
 
-import { updateMatchData } from '../../api/matches';
-import CustomPagination from '../../CustomPagination';
-import { useCallSetupStore } from '../../features/stores/index';
 import {
   getMatchEndpoint,
   RANDOM_CALL_LOBBY_ENDPOINT,
   USER_ENDPOINT,
-} from '../../features/swr/index';
+} from '../../api/endpoints';
+import { updateMatchData } from '../../api/matches';
+import CustomPagination from '../../CustomPagination';
+import { useCallSetupStore } from '../../features/stores/index';
 import useSystemModalBlocker from '../../hooks/useSystemModalBlocker';
 import {
   COMMUNITY_EVENTS_ROUTE,

--- a/src/components/views/LittleWorldWebNative.tsx
+++ b/src/components/views/LittleWorldWebNative.tsx
@@ -4,18 +4,18 @@ import { I18nextProvider } from 'react-i18next';
 import { RouterProvider } from 'react-router-dom';
 import useSWR, { mutate, SWRConfig } from 'swr';
 
+import {
+  API_OPTIONS_ENDPOINT,
+  API_TRANSLATIONS_ENDPOINT,
+  IS_AUTHENTICATED_ENDPOINT,
+  USER_ENDPOINT,
+} from '../../api/endpoints';
 import { apiFetch } from '../../api/helpers';
 import { TokenStatus } from '../../api/types';
 import { environment } from '../../environment';
 import { useReceiveHandlerStore } from '../../features/stores';
 import useNativeStore from '../../features/stores/nativeStore';
 import { DomCommunicationMessageFn } from '../../features/stores/receiveHandler';
-import {
-  API_OPTIONS_ENDPOINT,
-  API_TRANSLATIONS_ENDPOINT,
-  IS_AUTHENTICATED_ENDPOINT,
-  USER_ENDPOINT,
-} from '../../features/swr';
 import useNativeSwrConfig from '../../hooks/useNativeSwrConfig';
 import i18n, { updateTranslationResources } from '../../i18n';
 import { getNativeRouter } from '../../router/router';

--- a/src/components/views/Login.tsx
+++ b/src/components/views/Login.tsx
@@ -14,10 +14,7 @@ import { useTranslation } from 'react-i18next';
 import useSWR, { mutate } from 'swr';
 
 import { login } from '../../api';
-import {
-  IS_AUTHENTICATED_ENDPOINT,
-  USER_ENDPOINT,
-} from '../../features/swr/index';
+import { IS_AUTHENTICATED_ENDPOINT, USER_ENDPOINT } from '../../api/endpoints';
 import { onFormError, registerInput } from '../../helpers/form';
 import useQueryParam, { useRemoveQueryParam } from '../../hooks/useQueryParam';
 import {

--- a/src/components/views/MatchOverview/MatchOverview.tsx
+++ b/src/components/views/MatchOverview/MatchOverview.tsx
@@ -14,13 +14,13 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
-import type { ApiError } from '../../../api/types';
-import { USER_TYPES } from '../../../constants';
-import { useCallSetupStore } from '../../../features/stores/index';
 import {
   getMatchOverviewEndpoint,
   USER_ENDPOINT,
-} from '../../../features/swr/index';
+} from '../../../api/endpoints';
+import type { ApiError } from '../../../api/types';
+import { USER_TYPES } from '../../../constants';
+import { useCallSetupStore } from '../../../features/stores/index';
 import {
   activeWeekNumbers,
   deriveMatchState,

--- a/src/components/views/Messages.jsx
+++ b/src/components/views/Messages.jsx
@@ -3,10 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import { fetchChats } from '../../api/chat';
-import {
-  CHATS_ENDPOINT_SEPERATE,
-  MATCHES_ENDPOINT,
-} from '../../features/swr/index';
+import { CHATS_ENDPOINT_SEPERATE, MATCHES_ENDPOINT } from '../../api/endpoints';
 import useIniniteScroll from '../../hooks/useInfiniteScroll';
 import { getAppRoute, MESSAGES_ROUTE } from '../../router/routes';
 import PageHeader from '../atoms/PageHeader';

--- a/src/components/views/Notifications.tsx
+++ b/src/components/views/Notifications.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   ArchiveIcon,
   Button,
@@ -20,16 +18,16 @@ import { createSearchParams, useSearchParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import {
+  NOTIFICATIONS_ENDPOINT,
+  UNREAD_NOTIFICATIONS_ENDPOINT,
+} from '../../api/endpoints';
+import {
   deleteNotification,
   fetchNotifications,
   NotificationState,
   NotificationStateFilter,
   updateNotification,
 } from '../../api/notification';
-import {
-  NOTIFICATIONS_ENDPOINT,
-  UNREAD_NOTIFICATIONS_ENDPOINT,
-} from '../../features/swr/index';
 import PageHeader from '../atoms/PageHeader';
 import Toolbar from '../atoms/Toolbar';
 import UnreadIndicator from '../atoms/UnreadIndicator';

--- a/src/components/views/Onboarding/OnboardingSelection.tsx
+++ b/src/components/views/Onboarding/OnboardingSelection.tsx
@@ -12,8 +12,8 @@ import { Navigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import useSWR from 'swr';
 
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import { USER_TYPES } from '../../../constants';
-import { USER_ENDPOINT } from '../../../features/swr';
 import { getAppRoute } from '../../../router/routes';
 import LoadingScreen from '../../atoms/LoadingScreen';
 import PartnerActionCard from '../../blocks/Cards/PartnerActionCard';

--- a/src/components/views/Onboarding/OnboardingWalkthrough.tsx
+++ b/src/components/views/Onboarding/OnboardingWalkthrough.tsx
@@ -10,9 +10,9 @@ import {
   fetchSelfOnboardingCourse,
   SELF_ONBOARDING_COURSE_ENDPOINT,
 } from '../../../api/courses';
+import { USER_ENDPOINT } from '../../../api/endpoints';
 import updateSelfOnboardingStep from '../../../api/onboarding';
 import { USER_TYPES } from '../../../constants';
-import { USER_ENDPOINT } from '../../../features/swr';
 import {
   getCompletedChapterCountForStoredStep,
   getSelfOnboardingStepIdForChapter,

--- a/src/components/views/Profile.tsx
+++ b/src/components/views/Profile.tsx
@@ -16,16 +16,16 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import useSWR, { mutate } from 'swr';
 
+import {
+  API_OPTIONS_ENDPOINT,
+  MATCHES_ENDPOINT,
+  USER_ENDPOINT,
+} from '../../api/endpoints';
 import { mutateUserData } from '../../api/index';
 import { fetchUserMatch } from '../../api/matches';
 import { fetchProfile } from '../../api/profile';
 import { COUNTRIES, USER_TYPES } from '../../constants/index';
-import {
-  API_OPTIONS_ENDPOINT,
-  MATCHES_ENDPOINT,
-  revalidateMatches,
-  USER_ENDPOINT,
-} from '../../features/swr/index';
+import { revalidateMatches } from '../../features/swr';
 import { onFormError } from '../../helpers/form';
 import useSystemModalBlocker from '../../hooks/useSystemModalBlocker';
 import { EDIT_FORM_ROUTE, getAppRoute } from '../../router/routes';

--- a/src/components/views/RandomCalls/RandomCalls.tsx
+++ b/src/components/views/RandomCalls/RandomCalls.tsx
@@ -12,13 +12,13 @@ import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import useSWR from 'swr';
 
-import { exitLobby } from '../../../api/randomCalls';
-import { COMMUNITY_EVENT_FREQUENCIES } from '../../../constants/index';
 import {
   RANDOM_CALL_EXIT_PARAM,
   RANDOM_CALL_EXIT_VALUE,
   UPCOMING_LOBBIES_ENDPOINT,
-} from '../../../features/swr/index';
+} from '../../../api/endpoints';
+import { exitLobby } from '../../../api/randomCalls';
+import { COMMUNITY_EVENT_FREQUENCIES } from '../../../constants/index';
 import { type UpcomingLobbyItem } from '../../../helpers/randomCalls';
 import useSystemModalBlocker from '../../../hooks/useSystemModalBlocker';
 import randomCallsImage from '../../../images/random-calls-image.png';

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -23,7 +23,7 @@ import styled, { css, useTheme } from 'styled-components';
 import useSWR, { mutate } from 'swr';
 
 import { mutateUserData, setNewEmail, setNewPassword } from '../../api';
-import { USER_ENDPOINT } from '../../features/swr/index';
+import { USER_ENDPOINT } from '../../api/endpoints';
 import { onFormError, registerInput } from '../../helpers/form';
 import useSystemModalBlocker from '../../hooks/useSystemModalBlocker';
 import { FORGOT_PASSWORD_ROUTE } from '../../router/routes';

--- a/src/components/views/SignUp.tsx
+++ b/src/components/views/SignUp.tsx
@@ -25,7 +25,7 @@ import {
   API_OPTIONS_ENDPOINT,
   IS_AUTHENTICATED_ENDPOINT,
   USER_ENDPOINT,
-} from '../../features/swr/index';
+} from '../../api/endpoints';
 import { onFormError, registerInput } from '../../helpers/form';
 import { LOGIN_ROUTE, passAuthenticationBoundary } from '../../router/routes';
 import {

--- a/src/components/views/VerifyEmail.jsx
+++ b/src/components/views/VerifyEmail.jsx
@@ -18,7 +18,7 @@ import styled, { useTheme } from 'styled-components';
 import useSWR from 'swr';
 
 import { resendVerificationEmail, verifyEmail } from '../../api';
-import { USER_ENDPOINT } from '../../features/swr/index';
+import { USER_ENDPOINT } from '../../api/endpoints';
 import { onFormError, registerInput } from '../../helpers/form';
 import {
   CHANGE_EMAIL_ROUTE,

--- a/src/components/views/VideoCall.tsx
+++ b/src/components/views/VideoCall.tsx
@@ -31,18 +31,18 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import useSWR from 'swr';
 
+import {
+  getChatEndpoint,
+  RANDOM_CALL_EXIT_PARAM,
+  RANDOM_CALL_EXIT_VALUE,
+  USER_ENDPOINT,
+} from '../../api/endpoints';
 import { callAgain } from '../../api/livekit';
 import { endRandomCallMatch } from '../../api/randomCalls';
 import {
   useChatInputStore,
   useConnectedCallStore,
 } from '../../features/stores';
-import {
-  getChatEndpoint,
-  RANDOM_CALL_EXIT_PARAM,
-  RANDOM_CALL_EXIT_VALUE,
-  USER_ENDPOINT,
-} from '../../features/swr';
 import useIsBelowBreakpoint from '../../hooks/useIsBelowBreakpoint';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 import {

--- a/src/features/swr/index.ts
+++ b/src/features/swr/index.ts
@@ -1,41 +1,12 @@
-import type { SWRConfiguration } from 'swr';
-import { mutate } from 'swr';
+import { mutate, SWRConfiguration } from 'swr';
 
+import {
+  CHATS_ENDPOINT,
+  MATCHES_ENDPOINT,
+  NOTIFICATIONS_ENDPOINT,
+  USER_ENDPOINT,
+} from '../../api/endpoints';
 import { apiFetch } from '../../api/helpers';
-
-export const USER_ENDPOINT = '/api/user';
-export const IS_AUTHENTICATED_ENDPOINT = '/api/user/authenticated';
-export const COMMUNITY_EVENTS_ENDPOINT = '/api/community';
-export const RANDOM_CALL_HISTORY_ENDPOINT = '/api/random_calls/user/history';
-export const RANDOM_CALL_LOBBY_ENDPOINT =
-  '/api/random_calls/lobby/default/active_or_upcoming';
-export const UPCOMING_LOBBIES_ENDPOINT =
-  '/api/random_calls/upcoming?name=default';
-export const RANDOM_CALL_EXIT_PARAM = 'randomCallEnded';
-export const RANDOM_CALL_EXIT_VALUE = '1';
-export const apiOptions = '#api_options';
-export const API_OPTIONS_ENDPOINT = '/api/api_options';
-export const FIREBASE_ENDPOINT = '/api/firebase';
-export const MATCHES_ENDPOINT = '/api/matches';
-export const getMatchOverviewEndpoint = (matchUuid: string) =>
-  `/api/matches/${matchUuid}/overview`;
-export const ACTIVE_CALL_ROOMS_ENDPOINT = '/api/call_rooms';
-export const NOTIFICATIONS_ENDPOINT = '/api/notifications';
-export const UNREAD_NOTIFICATIONS_ENDPOINT = '/api/notifications?filter=unread';
-export const CHATS_ENDPOINT = '/api/chats/?page_size=20';
-export const CHATS_ENDPOINT_SEPERATE =
-  '/api/chats/?page_size=20&pagination=true';
-export const API_TRANSLATIONS_ENDPOINT = '/api/translations';
-
-export const getChatEndpoint = (chatId: string) => `/api/chats/${chatId}/`;
-export const getChatMessagesEndpoint = (chatId: string, page: number) =>
-  `/api/messages/${chatId}/?page=${page}&page_size=20`;
-export const getCommunityEventsEndpoint = (page: number, pageSize = 15) =>
-  `/api/community?page=${page}&page_size=${pageSize}`;
-export const getMatchEndpoint = (page: number) =>
-  `/api/matches?page=${page}&page_size=10`;
-export const getQuestionsEndpoint = (archived: boolean) =>
-  `/api/user/question_cards/?archived=${archived}&category=all`;
 
 export const revalidateMatches = () =>
   mutate(

--- a/src/features/swr/nativeTokenRefreshMiddleware.ts
+++ b/src/features/swr/nativeTokenRefreshMiddleware.ts
@@ -1,6 +1,6 @@
 import { mutate, type Middleware } from 'swr';
 
-import { IS_AUTHENTICATED_ENDPOINT, USER_ENDPOINT } from '.';
+import { IS_AUTHENTICATED_ENDPOINT, USER_ENDPOINT } from '../../api/endpoints';
 import { TokenStatus } from '../../api/types';
 import useNativeStore from '../stores/nativeStore';
 

--- a/src/features/swr/wsBridgeMutations.ts
+++ b/src/features/swr/wsBridgeMutations.ts
@@ -1,8 +1,6 @@
 import { isEmpty } from 'lodash';
 import { mutate } from 'swr';
 
-import { rejectCall } from '../../api/livekit';
-import useConnectedCallStore from '../stores/connectedCall';
 import {
   ACTIVE_CALL_ROOMS_ENDPOINT,
   CHATS_ENDPOINT,
@@ -10,7 +8,9 @@ import {
   getChatEndpoint,
   MATCHES_ENDPOINT,
   USER_ENDPOINT,
-} from './index';
+} from '../../api/endpoints';
+import { rejectCall } from '../../api/livekit';
+import useConnectedCallStore from '../stores/connectedCall';
 
 interface MatchesData {
   [category: string]: any[];

--- a/src/firebase-util.ts
+++ b/src/firebase-util.ts
@@ -8,8 +8,8 @@ import {
 } from '@firebase/app';
 import { getMessaging, getToken } from '@firebase/messaging';
 
+import { FIREBASE_ENDPOINT } from './api/endpoints';
 import { apiFetch } from './api/helpers';
-import { FIREBASE_ENDPOINT } from './features/swr';
 
 type FirebaseConfig = {
   clientConfig: FirebaseOptions;

--- a/src/guards/AuthGuard.tsx
+++ b/src/guards/AuthGuard.tsx
@@ -2,8 +2,8 @@ import { ReactNode, useMemo, useRef } from 'react';
 
 import useSWR from 'swr';
 
+import { IS_AUTHENTICATED_ENDPOINT } from '../api/endpoints';
 import useNativeStore from '../features/stores/nativeStore';
-import { IS_AUTHENTICATED_ENDPOINT } from '../features/swr/index';
 
 function AuthGuard({ children }: { children: ReactNode }) {
   const { data: authenticated, isValidating } = useSWR<boolean>(

--- a/src/guards/RouteGuard.tsx
+++ b/src/guards/RouteGuard.tsx
@@ -3,12 +3,11 @@ import { ComponentType } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import useSWR from 'swr';
 
+// import LoadingScreen from '../components/atoms/LoadingScreen';
+import { IS_AUTHENTICATED_ENDPOINT, USER_ENDPOINT } from '../api/endpoints';
 import { TokenStatus } from '../api/types';
 import { FullAppLayout } from '../components/blocks/Layout/AppLayout';
-// import { environment } from '../environment';
-// import LoadingScreen from '../components/atoms/LoadingScreen';
 import useNativeStore from '../features/stores/nativeStore';
-import { IS_AUTHENTICATED_ENDPOINT, USER_ENDPOINT } from '../features/swr';
 import {
   CHANGE_EMAIL_ROUTE,
   getAppRoute,

--- a/src/hooks/useSearchState.ts
+++ b/src/hooks/useSearchState.ts
@@ -2,9 +2,9 @@ import { useState } from 'react';
 
 import useSWR, { mutate } from 'swr';
 
+import { USER_ENDPOINT } from '../api/endpoints';
 import { updateUserSearchState } from '../api/profile';
 import { SEARCHING_STATES } from '../constants';
-import { USER_ENDPOINT } from '../features/swr/index';
 
 export interface SearchStateError {
   message?: string;

--- a/src/hooks/useSupportChat.ts
+++ b/src/hooks/useSupportChat.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 
-import { MATCHES_ENDPOINT } from '../features/swr';
+import { MATCHES_ENDPOINT } from '../api/endpoints';
 import { getAppSubpageRoute, MESSAGES_ROUTE } from '../router/routes';
 
 export interface SupportMatch {

--- a/src/hooks/useUnreadNotificationCount.ts
+++ b/src/hooks/useUnreadNotificationCount.ts
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 
+import { UNREAD_NOTIFICATIONS_ENDPOINT } from '../api/endpoints';
 import { fetchNotifications } from '../api/notification';
-import { UNREAD_NOTIFICATIONS_ENDPOINT } from '../features/swr/index';
 
 function useUnreadNotificationCount() {
   const response = useSWR(UNREAD_NOTIFICATIONS_ENDPOINT, fetchNotifications, {

--- a/src/main.js
+++ b/src/main.js
@@ -4,10 +4,10 @@ import { isEmpty } from 'lodash';
 import { createRoot } from 'react-dom/client';
 import { mutate } from 'swr';
 
+import { API_OPTIONS_ENDPOINT } from './api/endpoints';
 import App from './App';
 import MessageCard from './components/blocks/Cards/MessageCard';
 import FormLayout from './components/blocks/Layout/FormLayout';
-import { API_OPTIONS_ENDPOINT } from './features/swr/index';
 import { updateTranslationResources } from './i18n';
 import reportWebVitals from './reportWebVitals';
 import { Root } from './router/router';


### PR DESCRIPTION
To prevent running into circular import loops, move api endpoints to separate endpoints file